### PR TITLE
Change comment of sync_pre_hash to match code

### DIFF
--- a/snapraid-daily
+++ b/snapraid-daily
@@ -414,7 +414,7 @@ read_config_file() {
     echo "INFO: Notification Emails & Hook(s) disabled on Success"
   fi
 
-  # Check for sync_pre_hash, default to no. Sanity check it's "yes" or "no"
+  # Check for sync_pre_hash, default to yes. Sanity check it's "yes" or "no"
   if [ -z "${sync_pre_hash}" ]; then
     sync_pre_hash="yes"
   elif [ "${sync_pre_hash}" != "yes" ] && [ "${sync_pre_hash}" != "no" ]; then


### PR DESCRIPTION
Looks like **sync_pre_hash** should default to yes. I changed the comment to match the code.

https://github.com/zoot101/snapraid-daily/blob/85f9cc8feaa59551a2d3bdf102b43a38e4b47fe1/snapraid-daily#L417-L422

https://github.com/zoot101/snapraid-daily/blob/85f9cc8feaa59551a2d3bdf102b43a38e4b47fe1/config/snapraid-daily.conf#L64-L65